### PR TITLE
Use `npm ci` for package installation in node based Dockerfiles

### DIFF
--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 # Copy dependency descriptors
 COPY package.json package-lock.json .npmrc ./
 # Install dependencies
-RUN npm i --only=prod
+RUN npm ci --only=prod
 # Cleanup
 RUN rm .npmrc
 

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 # Copy dependency descriptors
 COPY package.json package-lock.json .npmrc ./
 # Install dependencies
-RUN npm i
+RUN npm ci
 # Build
 COPY src ./src
 COPY  tsconfig.json ./
@@ -21,7 +21,7 @@ WORKDIR /app
 # Copy dependency descriptors
 COPY package.json package-lock.json .npmrc ./
 # Install dependencies
-RUN npm i --only=prod
+RUN npm ci --only=prod
 # Cleanup
 RUN rm .npmrc
 


### PR DESCRIPTION
`npm ci` is preferred above `npm i` on automated & deployment environments: https://docs.npmjs.com/cli/v7/commands/npm-ci

Co-authored-by: KaposiOli <oliver.kaposi@gmail.com>